### PR TITLE
tile_images update

### DIFF
--- a/gates/init.lua
+++ b/gates/init.lua
@@ -21,14 +21,14 @@
 -- {
 --     #open gate options go here
 --
---     tile_images = {'open_gate.png'}, 
+--     tiles = {'open_gate.png'}, 
 --	   walkable = false,
 --     drawtype = "plantlike",
 -- },
 -- {
 --     #closed gate options go here
 --
---     tile_images = {'closed_gate_top.png','closed_gate_bottom.png','closed_gate_sides.png'}, 
+--     tiles = {'closed_gate_top.png','closed_gate_bottom.png','closed_gate_sides.png'}, 
 --	   walkable = true,
 -- },
 -- })

--- a/gates_iron/init.lua
+++ b/gates_iron/init.lua
@@ -35,11 +35,11 @@ gates.register_gate('gates_iron:classic', {
     sunlight_propagates = true,
     paramtype = 'light',
     visual_scale = 1.5,
-	tile_images = {'gate_iron_open.png'},
+	tiles = {'gate_iron_open.png'},
 	walkable = false,
 },
 {
-	tile_images = {'gate_iron_top.png','gate_iron_top.png','gate_iron.png'},
+	tiles = {'gate_iron_top.png','gate_iron_top.png','gate_iron.png'},
 	walkable = true,
 }, "on_mesecon")
 
@@ -54,7 +54,7 @@ gates.register_gate('gates_iron:long', {
 			{-0.9, -0.25, -0.1, 0.9, 0.25, 0.1},
 		},
 	},
-	tile_images = {'gate_iron_texture.png'},
+	tiles = {'gate_iron_texture.png'},
 	sunlight_propagates = true,
     paramtype = "light",
     open_on_rightclick = true,
@@ -95,7 +95,7 @@ gates.register_gate('gates_iron:short', {
 			{-0.5, -0.5, -0.06, 0.5, 0.5, 0.06},
 		},
 	},
-	tile_images = {'gate_iron_texture.png'},
+	tiles = {'gate_iron_texture.png'},
 	sunlight_propagates = true,
     paramtype = "light",
     open_on_rightclick = true,

--- a/gates_wooden/init.lua
+++ b/gates_wooden/init.lua
@@ -16,7 +16,7 @@ gates.register_gate('gates_wooden:long', {
 			{-0.9, -0.25, -0.1, 0.9, 0.25, 0.1},
 		},
 	},
-	tile_images = {'default_wood.png'},
+	tiles = {'default_wood.png'},
 	sunlight_propagates = true,
     paramtype = "light",
     open_on_rightclick = true
@@ -53,7 +53,7 @@ gates.register_gate('gates_wooden:short', {
 			{-0.5, -0.5, -0.06, 0.5, 0.5, 0.06},
 		},
 	},
-	tile_images = {'default_wood.png'},
+	tiles = {'default_wood.png'},
 	--sunlight_propagates = true,
     paramtype = "light",
     open_on_rightclick = true,
@@ -103,7 +103,7 @@ gates.register_gate('gates_wooden:classic', {
     sunlight_propagates = true,
     paramtype = "light",
     visual_scale = 1.5,
-	tile_images = {'gate_wooden_open.png'},
+	tiles = {'gate_wooden_open.png'},
 	walkable = false,
 	selection_box = {
 		type = "fixed",
@@ -116,7 +116,7 @@ gates.register_gate('gates_wooden:classic', {
 	},
 },
 {
-	tile_images = {'gate_wooden_top.png','gate_wooden_top.png','gate_wooden.png'},
+	tiles = {'gate_wooden_top.png','gate_wooden_top.png','gate_wooden.png'},
 	walkable = true,
 })
 


### PR DESCRIPTION
I've been seeing a warning that `tile_images` is deprecated in my server logs for a while now, and I just recently got around to tracking it down to this mod.

This pull requests fixes this so that the warnings should go away :-)